### PR TITLE
fix: now using es6 export

### DIFF
--- a/packages/ui-predicate-vue/src/UIPredicateCoreVue.js
+++ b/packages/ui-predicate-vue/src/UIPredicateCoreVue.js
@@ -60,4 +60,4 @@ function UIPredicateCoreVue({ data, columns, options } = {}) {
 
 UIPredicateCoreVue.defaults = defaults;
 
-module.exports = { UIPredicateCoreVue };
+export { UIPredicateCoreVue };

--- a/packages/ui-predicate-vue/src/ui-predicate-comparison-argument.js
+++ b/packages/ui-predicate-vue/src/ui-predicate-comparison-argument.js
@@ -4,7 +4,7 @@ import Vue from 'vue';
  * as long as these UIcomponents were registered in UIPredicateCore ArgumentType registry
  * @type {Vue.Component}
  */
-module.exports = Vue.component('ui-predicate-comparison-argument', {
+export default {
   render(createElement) {
     return createElement(
       this.getArgumentTypeComponentById(
@@ -31,4 +31,4 @@ module.exports = Vue.component('ui-predicate-comparison-argument', {
       required: true,
     },
   },
-});
+};

--- a/packages/ui-predicate-vue/src/ui-predicate-comparison.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate-comparison.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
   name: 'ui-predicate-comparison',
   props: {
     predicate: {

--- a/packages/ui-predicate-vue/src/ui-predicate-compound.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate-compound.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
   name: 'ui-predicate-compound',
   props: {
     compound: {

--- a/packages/ui-predicate-vue/src/ui-predicate-options.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate-options.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
   name: 'ui-predicate-options',
   props: {
     predicate: {

--- a/packages/ui-predicate-vue/src/ui-predicate.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate.vue
@@ -9,7 +9,7 @@
 <script>
 import { UIPredicateCoreVue } from './UIPredicateCoreVue';
 
-module.exports = {
+export default {
   name: 'ui-predicate',
   props: {
     config: {


### PR DESCRIPTION
### Prerequisites
- [ x] I have read the [Contributing guidelines](https://github.com/fgribreau/ui-predicate/blob/master/.github/CONTRIBUTING.md)
- [x ] I have read the [Code of conduct](https://github.com/fgribreau/ui-predicate/blob/master/.github/CODE_OF_CONDUCT.md) and I agree with it

### Description
On VueJS plugin, changed `module.exports` to ES6 syntax `export [default]`.