### PR TITLE
fix(core): remove build script after installing the package

### DIFF
--- a/packages/ui-predicate-core/package.json
+++ b/packages/ui-predicate-core/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "jest -c ../../jest.js --coverage",
     "test:debugger": "node --inspect-brk node_modules/.bin/jest --watch",
-    "postinstall": "npm run build",
     "build": "parcel build --out-file=ui-predicate-core --out-dir=lib --no-cache --detailed-report --target=browser src/index.js",
     "test:watch": "jest  --coverage --watch",
     "test:coverage": "jest -c ../../jest.js --maxWorkers=2 --coverage",


### PR DESCRIPTION
### Prerequisites
- [x] I have read the [Contributing guidelines](https://github.com/fgribreau/ui-predicate/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Code of conduct](https://github.com/fgribreau/ui-predicate/blob/master/.github/CODE_OF_CONDUCT.md) and I agree with it

### Description
Removes the build script in the postinstall step, because this is executed on user's projects when they add the package as a dependency.

As seen in npm documentation (last bullet-point here https://docs.npmjs.com/misc/scripts#best-practices), the postinstall script is used to execute steps that must be executed on client machines (native compilation that is platform dependant for example)

**Issue :** #10 
