### PR TITLE
fix: missing default_argument component overriding and predicate-options display

### DIFF
--- a/packages/ui-predicate-core/src/PredicateCore.js
+++ b/packages/ui-predicate-core/src/PredicateCore.js
@@ -278,7 +278,7 @@ module.exports = function({ dataclasses, invariants, errors, rules, UITypes }) {
    * @memberof core
    */
   function PredicateCore(args) {
-    const { data, columns, ui, options } = args;
+    const { data, columns, ui: _ui, options } = args;
 
     return new Promise((resolve, reject) => {
       try {
@@ -568,7 +568,7 @@ module.exports = function({ dataclasses, invariants, errors, rules, UITypes }) {
             )
             .map(argumentType => argumentType.component)
             .valueOrElse(() =>
-              _options.getDefaultArgumentComponent(_columns, _options)
+              _options.getDefaultArgumentComponent(_columns, _options, _ui)
             );
         }
 

--- a/packages/ui-predicate-vue/.storybook/preview-head.html
+++ b/packages/ui-predicate-vue/.storybook/preview-head.html
@@ -14,27 +14,30 @@ So, these won’t be loaded into the main Storybook UI. -->
 .custom-css .ui-predicate__row--compound,
 .custom-css .ui-predicate__row--comparison,
 .custom-css .ui-predicate__col,
-.custom-css .ui-predicate__col--targets,
-.custom-css .ui-predicate__col--operators,
-.custom-css .ui-predicate__col--arguments,
-.custom-css .ui-predicate__col--options,
-.custom-css .ui-predicate__col--logic{
+.custom-css .ui-predicate__targets,
+.custom-css .ui-predicate__operators,
+.custom-css .ui-predicate__arguments,
+.custom-css .ui-predicate__options,
+.custom-css .ui-predicate__option,
+.custom-css .ui-predicate__logic{
   position: relative;
   margin: 4px;
   background: rgba(0,0,0,0.1);
-  padding: 15px;
+  padding: 4px;
+  vertical-align: top;
 }
 
-.custom-css .ui-predicate__main::after,
-.custom-css .ui-predicate__row::after,
-.custom-css .ui-predicate__row--compound::after,
-.custom-css .ui-predicate__row--comparison::after,
-.custom-css .ui-predicate__col::after,
-.custom-css .ui-predicate__col--targets::after,
-.custom-css .ui-predicate__col--operators::after,
-.custom-css .ui-predicate__col--arguments::after,
-.custom-css .ui-predicate__col--options::after,
-.custom-css .ui-predicate__col--logic::after{
+.custom-css .ui-predicate__main::before,
+.custom-css .ui-predicate__row::before,
+.custom-css .ui-predicate__row--compound::before,
+.custom-css .ui-predicate__row--comparison::before,
+.custom-css .ui-predicate__col::before,
+.custom-css .ui-predicate__targets::before,
+.custom-css .ui-predicate__operators::before,
+.custom-css .ui-predicate__arguments::before,
+.custom-css .ui-predicate__options::before,
+.custom-css .ui-predicate__option::before,
+.custom-css .ui-predicate__logic::before{
   display: block;
   font-size: 10px;
   font-family: monospace;
@@ -43,34 +46,37 @@ So, these won’t be loaded into the main Storybook UI. -->
 }
 
 /** */
-.custom-css .ui-predicate__main::after{
+.custom-css .ui-predicate__main::before{
   content:'.ui-predicate__main';
 }
-.custom-css .ui-predicate__row::after{
+.custom-css .ui-predicate__row::before{
   content:'.ui-predicate__row';
 }
-.custom-css .ui-predicate__row--compound::after{
+.custom-css .ui-predicate__row--compound::before{
   content:'.ui-predicate__row.ui-predicate__row--compound';
 }
-.custom-css .ui-predicate__row--comparison::after{
+.custom-css .ui-predicate__row--comparison::before{
   content:'.ui-predicate__row.ui-predicate__row--comparison';
 }
-.custom-css .ui-predicate__col::after{
+.custom-css .ui-predicate__col::before{
   content:'.ui-predicate__col';
 }
-.custom-css .ui-predicate__col--targets::after{
-  content:'.ui-predicate__col.ui-predicate__col--targets';
+.custom-css .ui-predicate__targets::before{
+  content:'..ui-predicate__targets';
 }
-.custom-css .ui-predicate__col--operators::after{
-  content:'.ui-predicate__col.ui-predicate__col--operators';
+.custom-css .ui-predicate__operators::before{
+  content:'.ui-predicate__operators';
 }
-.custom-css .ui-predicate__col--arguments::after{
-  content:'.ui-predicate__col.ui-predicate__col--arguments';
+.custom-css .ui-predicate__arguments::before{
+  content:'.ui-predicate__arguments';
 }
-.custom-css .ui-predicate__col--options::after{
-  content:'.ui-predicate__col.ui-predicate__col--options';
+.custom-css .ui-predicate__options::before{
+  content:'.ui-predicate__options';
 }
-.custom-css .ui-predicate__col--logic::after{
-  content:'.ui-predicate__col.ui-predicate__col--logic';
+.custom-css .ui-predicate__option::before{
+  content:'.ui-predicate__option';
+}
+.custom-css .ui-predicate__logic::before{
+  content:'.ui-predicate__logic';
 }
 </style>

--- a/packages/ui-predicate-vue/src/UIPredicateCoreVue.js
+++ b/packages/ui-predicate-vue/src/UIPredicateCoreVue.js
@@ -15,21 +15,31 @@ const defaults = {
   options: {
     /**
      * UIPredicate Vue Adapter own default argument component
+     * @param {Object} [columns=PredicateCore.defaults.columns] columns
+     * @param {Object} [options=PredicateCore.defaults.options] options
+     * @param {Object} [ui=PredicateCore.defaults.ui] ui
      * @return {Vue.component} the default Vue Component to use as argument specifier
      * @see core.defaults.getDefaultArgumentComponent
      * @memberof vue.defaults
      */
-    getDefaultArgumentComponent() {
-      return DEFAULT_COMPONENTS[UITypes.ARGUMENT_DEFAULT];
+    getDefaultArgumentComponent(columns, options, ui) {
+      /*
+        "ui" arg. results from DEFAULT_COMPONENTS
+        and :ui attribute passed to <ui-predicate>
+        all merged in UIPredicateCoreVue()
+        and passed to PredicateCore
+      */
+      return ui[UITypes.ARGUMENT_DEFAULT];
     },
   },
 };
 
 /**
  * UIPredicateCore adapter for VueJS
- * @param       {?dataclasses.CompoundPredicate} [data=PredicateCore.defaults.options.getDefaultData] data
- * @param       {Object} [columns=PredicateCore.defaults.columns] columns
- * @param       {Object} [options=PredicateCore.defaults.options] options
+ * @param {?dataclasses.CompoundPredicate} [data=PredicateCore.defaults.options.getDefaultData] data
+ * @param {Object} [columns=PredicateCore.defaults.columns] columns
+ * @param {Object} [ui=PredicateCore.defaults.ui] ui
+ * @param {Object} [options=PredicateCore.defaults.options] options
  * @return {Promise<core.PredicateCoreAPI>} resolved promise yield a PredicateCoreAPI
  * @memberof vue
  */

--- a/packages/ui-predicate-vue/src/ui-predicate-comparison.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate-comparison.vue
@@ -1,26 +1,31 @@
 <template>
   <div class="ui-predicate__row ui-predicate__row--comparison">
-      <div class="ui-predicate__col ui-predicate__col--targets">
+      <div class="ui-predicate__col">
         <component
+          class="ui-predicate__targets"
           :is="getUIComponent(UITypes.TARGETS)"
           :columns="columns"
           :predicate="predicate"
           @change="changeTarget($event)"
         />
       </div>
-      <div class="ui-predicate__col ui-predicate__col--operators">
+      <div class="ui-predicate__col">
         <component
+          class="ui-predicate__operators"
           :is="getUIComponent(UITypes.OPERATORS)"
           :columns="columns"
           :predicate="predicate"
           @change="changeOperator($event)"
         />
       </div>
-      <div class="ui-predicate__col ui-predicate__col--arguments">
-        <ui-predicate-comparison-argument :predicate="predicate"></ui-predicate-comparison-argument>
+      <div class="ui-predicate__col">
+        <ui-predicate-comparison-argument
+          class="ui-predicate__arguments"
+          :predicate="predicate"
+        />
       </div>
-      <div class="ui-predicate__col ui-predicate__col--options">
-        <ui-predicate-options :predicate="predicate"></ui-predicate-options>
+      <div class="ui-predicate__col">
+        <ui-predicate-options :predicate="predicate" />
       </div>
     </div>
 </template>

--- a/packages/ui-predicate-vue/src/ui-predicate-compound.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate-compound.vue
@@ -1,8 +1,9 @@
 <template>
     <div class="ui-predicate__row--compound">
       <div class="ui-predicate__row">
-        <div class="ui-predicate__col ui-predicate__col--logic">
+        <div class="ui-predicate__col">
           <component
+            class="ui-predicate__logic"
             v-if="predicate.logic"
             :is="getUIComponent(UITypes.LOGICAL_TYPES)"
             :predicate="predicate"
@@ -10,7 +11,7 @@
             @change="changeLogic($event)"
           />
         </div>
-        <div class="ui-predicate__col ui-predicate__col--options">
+        <div class="ui-predicate__col">
           <ui-predicate-options :predicate="predicate"></ui-predicate-options>
         </div>
       </div>

--- a/packages/ui-predicate-vue/src/ui-predicate-options.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate-options.vue
@@ -1,17 +1,21 @@
 <template>
-  <div>
-    <component
-      :is="getUIComponent(UITypes.PREDICATE_REMOVE)"
-      @click.native="remove(predicate)"
-      :predicate="predicate"
-      :disabled="predicate.$canBeRemoved === false"
-    />
-    <component
-      :is="getUIComponent(UITypes.PREDICATE_ADD)"
-      @click.native="add(predicate)"
-      :predicate="predicate"
-      :is-in-add-compound-mode="isInAddCompoundMode"
-    />
+  <div class="ui-predicate__options">
+    <div class="ui-predicate__option">
+      <component
+        :is="getUIComponent(UITypes.PREDICATE_REMOVE)"
+        @click.native="remove(predicate)"
+        :predicate="predicate"
+        :disabled="predicate.$canBeRemoved === false"
+      />
+    </div>
+    <div class="ui-predicate__option">
+      <component
+        :is="getUIComponent(UITypes.PREDICATE_ADD)"
+        @click.native="add(predicate)"
+        :predicate="predicate"
+        :is-in-add-compound-mode="isInAddCompoundMode"
+      />
+    </div>
   </div>
 </template>
 

--- a/packages/ui-predicate-vue/src/ui-predicate.stories.js
+++ b/packages/ui-predicate-vue/src/ui-predicate.stories.js
@@ -191,11 +191,12 @@ storiesOf('ui-predicate', module)
           - \\\`.ui-predicate__row--compound\\\`: select every predicate compound row div containers
           - \\\`.ui-predicate__row--comparison\\\`: select every predicate comparison row div containers
           - \\\`.ui-predicate__col\\\`: select every column (targets, operators, arguments and option) div containers
-          - \\\`.ui-predicate__col--targets\\\`: select the every target columns div container
-          - \\\`.ui-predicate__col--operators\\\`: select every operators div container
-          - \\\`.ui-predicate__col--arguments\\\`: select every arguments div container
-          - \\\`.ui-predicate__col--options\\\`: select every option div container
-          - \\\`.ui-predicate__col--logic\\\`: select every logic div container
+          - \\\`.ui-predicate__targets\\\`: select the every target columns div container
+          - \\\`.ui-predicate__operators\\\`: select every operators div container
+          - \\\`.ui-predicate__arguments\\\`: select every arguments div container
+          - \\\`.ui-predicate__options\\\`: select every option div container
+          - \\\`.ui-predicate__option\\\`: select one option div container
+          - \\\`.ui-predicate__logic\\\`: select every logic div container
         `,
       },
     }

--- a/packages/ui-predicate-vue/src/ui-predicate.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate.vue
@@ -142,4 +142,7 @@ export default {
 .ui-predicate__col {
   display: inline-block;
 }
+.ui-predicate__options {
+  display: flex;
+}
 </style>


### PR DESCRIPTION
### Prerequisites
- [x] I have read the [Contributing guidelines](https://github.com/fgribreau/ui-predicate/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Code of conduct](https://github.com/fgribreau/ui-predicate/blob/master/.github/CODE_OF_CONDUCT.md) and I agree with it

### Description
Minor fix to handle UITypes.DEFAULT_ARGUMENT component if override wanted.