### PR TITLE
fix: remove console.error and emit event when creation fail

### DIFF
--- a/packages/ui-predicate-vue/src/errors.js
+++ b/packages/ui-predicate-vue/src/errors.js
@@ -1,0 +1,5 @@
+const errorEx = require('error-ex');
+
+module.exports = {
+  InitialisationFailed: errorEx('InitialisationFailed')
+};

--- a/packages/ui-predicate-vue/src/index.js
+++ b/packages/ui-predicate-vue/src/index.js
@@ -1,3 +1,4 @@
+const errors = require('./errors');
 const UIPredicateOptions = require('./ui-predicate-options.vue');
 const UIPredicateComparison = require('./ui-predicate-comparison.vue');
 const UIPredicateComparisonArgument = require('./ui-predicate-comparison-argument');
@@ -39,6 +40,7 @@ module.exports = {
   UIPredicateComparisonArgument,
   UIPredicateCompound,
   UIPredicate,
+  errors
 };
 
 module.exports.default = module.exports;

--- a/packages/ui-predicate-vue/src/ui-predicate.vue
+++ b/packages/ui-predicate-vue/src/ui-predicate.vue
@@ -116,7 +116,7 @@ export default {
         vm.$emit('initialized', ctrl);
       },
       err => {
-        console.error(err);
+        vm.$emit('initErrorCaptured', err);
       }
     );
 


### PR DESCRIPTION
### Prerequisites
- [x] I have read the [Contributing guidelines](https://github.com/fgribreau/ui-predicate/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Code of conduct](https://github.com/fgribreau/ui-predicate/blob/master/.github/CODE_OF_CONDUCT.md) and I agree with it

### Description
Actually error at vue ui-predicate component init was treated with `console.error`.
This way not permit parent component to react on init error.

We propose 
* change `console.error` to `error` event
* `created` hook return Promise to be treated by vue >= 2.6

### Example usage

```html
<ui-predicate v-if="state !== 'ERROR'"
        :data="predicate"
        :columns="predicateColumnsDefinition"
        :ui="predicateUiComponents"
        @initialized="state  = 'DONE'"
        @error="onError"
        @change="$emit('change', $event)"
/>
```
```javascript
import { errors as coreError } from 'ui-predicate-core';
import { errors as vueError } from 'ui-predicate-vue';
...
onError(error) {
      if (error instanceof vueErrors.InitialisationFailed) {
           ...
           if (error.cause instanceof coreError.Target_idMustReferToADefinedTarget) {
               ...
           }
      }
}
```

### Example usage with vue >= 2.6


```html
<ui-predicate v-if="state !== 'ERROR'"
        :data="predicate"
        :columns="predicateColumnsDefinition"
        :ui="predicateUiComponents"
        @initialized="state  = 'DONE'"
        @change="$emit('change', $event)"
/>
```
```javascript
import { errors as coreError } from 'ui-predicate-core';
import { errors as vueError } from 'ui-predicate-vue';
...
errorCaptured (error, vm, info) {
      if (error instanceof vueErrors.InitialisationFailed) {
           ...
           if (error.cause instanceof coreError.Target_idMustReferToADefinedTarget) {
               ...
           }
      }
}
```